### PR TITLE
Fix: Make LLM use absolute paths for workspace

### DIFF
--- a/workspace/workspace.py
+++ b/workspace/workspace.py
@@ -24,4 +24,5 @@ for file in files:
         print(f'  {file}/')
     else:
         print(f'  {file}')
+print("Always use absolute paths to interact with files in the workspace")
 print()


### PR DESCRIPTION
I'm hitting a lot of bugs where even though the LLM knows where the
workspace is and what files are in it, it tries to reference those files
as though they were in the current working dir. This instructs the LLM
to always reference workspace files with absolute paths.

Signed-off-by: Craig Jellick <craig@acorn.io>
